### PR TITLE
Remove en/latest/ from nbsphinx URL

### DIFF
--- a/docs/nbsphinx.ipynb
+++ b/docs/nbsphinx.ipynb
@@ -7,7 +7,7 @@
     "# nbsphinx\n",
     "\n",
     "* Homepage: https://github.com/spatialaudio/nbsphinx/\n",
-    "* Documentation: https://nbsphinx.readthedocs.io/en/latest/\n",
+    "* Documentation: https://nbsphinx.readthedocs.io/\n",
     "\n",
     "`nbsphinx` allows you to publish Jupyter notebooks as documentation pages.\n",
     "\n",


### PR DESCRIPTION
This way, it automatically gets re-directed to the documentation of the most recent release.
The `latest` version might mention features/options that aren't yet released, which could cause confusion.

Thanks for mentioning `nbsphinx`, BTW!