### PR TITLE
nbsphinx plots

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,10 @@ extensions = [
 ]
 
 nbsphinx_execute = 'auto'
+nbsphinx_execute_arguments = [
+    "--InlineBackend.figure_formats={'svg', 'pdf'}",
+    "--InlineBackend.rc={'figure.dpi': 96}",
+]
 
 autoapi_dirs = [
     'sphinx-notfound-page/notfound',

--- a/docs/ipython_kernel_config.py
+++ b/docs/ipython_kernel_config.py
@@ -1,0 +1,2 @@
+c.InlineBackend.figure_formats = {'svg'}
+c.InlineBackend.rc = {'figure.dpi': 96}

--- a/docs/nbsphinx.ipynb
+++ b/docs/nbsphinx.ipynb
@@ -34,22 +34,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "# Data for plotting\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Data for plotting:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "t = np.arange(0.0, 2.0, 0.01)\n",
-    "s = 1 + np.sin(2 * np.pi * t)\n",
-    "\n",
+    "s = 1 + np.sin(2 * np.pi * t)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig, ax = plt.subplots()\n",
     "ax.plot(t, s)\n",
-    "\n",
-    "ax.set(xlabel='time (s)', ylabel='voltage (mV)',\n",
-    "       title='About as simple as it gets, folks')\n",
-    "ax.grid()\n",
-    "\n",
-    "plt.show()"
+    "ax.set(\n",
+    "    xlabel='time (s)',\n",
+    "    ylabel='voltage (mV)',\n",
+    "    title='About as simple as it gets, folks',\n",
+    ")\n",
+    "ax.grid()"
    ]
   },
   {


### PR DESCRIPTION
Sadly, the default plotting settings in Jupyter notebooks are wrong, because they use the wrong DPI setting.

This corrects the DPI setting, but at the same time switches to SVG output (which makes the DPI setting obsolete).

Anyway, in the end the size of the plots is correct, see also https://nbsphinx.readthedocs.io/code-cells.html#Plots.

This uses PDF images for the LaTeX/PDF output, making the plots look much nicer in the PDF.