### PR TITLE
Avoid warning from traitlets

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ autosectionlabel_prefix_document = True
 nbsphinx_execute = 'auto'
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
-    "--InlineBackend.rc={'figure.dpi': 96}",
+    "--InlineBackend.rc=figure.dpi=96",
 ]
 
 autoapi_dirs = [


### PR DESCRIPTION
Starting with `traitlets` version 5.0, a warning is shown, see also https://github.com/spatialaudio/nbsphinx/issues/546.

Please note that the config file [docs/ipython_kernel_config.py](https://github.com/humitos/sphinx-extensions/blob/master/docs/ipython_kernel_config.py) is not working anymore, see https://github.com/ipython/ipython/issues/13663.

I hope we can find another reasonable way to provide those settings.