### PR TITLE
Remove [sphinx] extra from myst-parser

### DIFF
--- a/docs/myst-parser.md
+++ b/docs/myst-parser.md
@@ -1,9 +1,9 @@
-# myst-parser[sphinx]
+# myst-parser
 
 * **Homepage**: [https://github.com/ExecutableBookProject/MyST-Parser](https://github.com/ExecutableBookProject/MyST-Parser)
 * **Documentation**: [https://myst-parser.readthedocs.io/en/latest/](https://myst-parser.readthedocs.io/en/latest/)
 
-`myst-parser[sphinx]` is a Markdown parser (`.md` files) that allows you to
+`myst-parser` is a Markdown parser (`.md` files) that allows you to
 combine all the power of Markdown with all the potential of
 Sphinx. All at once!
 
@@ -19,7 +19,7 @@ As you can see, Sphinx extensions keep working without changes (e.g. `sphinx-pro
 ## Installation
 
 ```bash
-pip install myst-parser[sphinx]
+pip install myst-parser
 ```
 
 


### PR DESCRIPTION
Upstream moved Sphinx into the main requirements in 0.9.0 (executablebooks/MyST-Parser#170).