### PR TITLE
Update to sphinx-favicon 1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,15 +42,14 @@ extensions = [
     'nbsphinx',
     'sphinx_last_updated_by_git',
     'sphinx_design',
-    'sphinx-favicon',
+    'sphinx_favicon',
 ]
 
 
 favicons = [
    {
       "rel": "icon",
-      "static-file": "favicon.svg",
-      "type": "image/svg+xml",
+      "href": "favicon.svg",
    },
 ]
 autosectionlabel_prefix_document = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -226,7 +226,7 @@ sphinx-copybutton==0.5.1
     # via -r docs/requirements.in
 sphinx-design==0.3.0
     # via -r docs/requirements.in
-sphinx-favicon==0.2
+sphinx-favicon==1.0
     # via -r docs/requirements.in
 sphinx-last-updated-by-git==0.3.4
     # via -r docs/requirements.in

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -226,7 +226,7 @@ sphinx-copybutton==0.5.1
     # via -r docs/requirements.in
 sphinx-design==0.3.0
     # via -r docs/requirements.in
-sphinx-favicon==1.0
+sphinx-favicon==1.0.1
     # via -r docs/requirements.in
 sphinx-last-updated-by-git==0.3.4
     # via -r docs/requirements.in

--- a/docs/sphinx-favicon.rst
+++ b/docs/sphinx-favicon.rst
@@ -5,7 +5,7 @@ sphinx-favicon
    https://github.com/tcmetzger/sphinx-favicon
 
 :Documentation:
-   https://github.com/tcmetzger/sphinx-favicon#readme
+   https://sphinx-favicon.readthedocs.io/en/latest/
 
 With ``sphinx-favicon``, you can add custom favicons to your Sphinx html
 documentation quickly and easily.
@@ -17,7 +17,7 @@ and any favicon size.
 
 The ``sphinx-favicon`` extension gives you more flexibility than the `standard
 favicon.ico supported by Sphinx
-<https://www.sphinx-doc.org/en/master/templating.html?highlight=favicon#favicon_url>`_.
+<https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_favicon>`_.
 It provides a quick and easy way to add the most important favicon formats for
 different browsers and devices.
 
@@ -67,5 +67,5 @@ Configuration
       },
    ]
 
-See `the project readme on GitHub <https://github.com/tcmetzger/sphinx-favicon#readme>`_
+See `the project documentation <https://sphinx-favicon.readthedocs.io/en/latest/>`_
 for more configuration options!

--- a/docs/sphinx-favicon.rst
+++ b/docs/sphinx-favicon.rst
@@ -63,7 +63,7 @@ Configuration
       {
          "rel": "apple-touch-icon",
          "sizes": "180x180",
-         "href": "https://secure.example.com/favicon/apple-touch-icon-180x180.png",
+         "href": "apple-touch-icon-180x180.png",  # use a local file in _static
       },
    ]
 


### PR DESCRIPTION
Thanks for highlighting [Sphinx Favicon](https://github.com/tcmetzger/sphinx-favicon) in your project! I just released version 1.0 of the extension, which brings one breaking change: to better conform with Python standards, we changed the module name to `sphinx_favicon` (instead of `sphinx-favicon`). This means you'll have to update your conf.py file to use version 1.0. We have also simplified the favicon configuration, so I also updated the `favicons` list in conf.py.