### PR TITLE
Replace ipython_kernel_config.py with matplotlibrc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,6 @@ autosectionlabel_prefix_document = True
 nbsphinx_execute = 'auto'
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
-    "--InlineBackend.rc=figure.dpi=96",
 ]
 
 autoapi_dirs = [

--- a/docs/ipython_kernel_config.py
+++ b/docs/ipython_kernel_config.py
@@ -1,2 +1,0 @@
-c.InlineBackend.figure_formats = {'svg'}
-c.InlineBackend.rc = {'figure.dpi': 96}

--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,0 +1,1 @@
+figure.dpi: 96


### PR DESCRIPTION
Using `ipython_kernel_config.py` in the current directory doesn't work anymore (it has been disabled for security reasons).

Instead, `matplotlibrc` can be used. However, the `figure_formats` cannot be changed with that.

This suggested change will show the default PNG format in JupyterLab at al. (as it has done already, since `ipython_kernel_config.py` has no effect anymore), but it uses the correct DPI (which should be the only visible change of this PR).
The Sphinx-generated plot uses SVG in HTML output and PDF in LaTeX output (as before).

See also https://nbsphinx.readthedocs.io/en/0.9.3/code-cells.html#Plots and https://nbviewer.org/github/mgeier/python-audio/blob/master/plotting/matplotlib-inline-defaults.ipynb.