### PR TITLE
Upgrade ipython to fix nbsphinx syntax highlighting

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -60,7 +60,7 @@ imagesize==1.4.1
     # via sphinx
 ipykernel==6.17.1
     # via -r docs/requirements.in
-ipython==8.7.0
+ipython==8.16.0
     # via ipykernel
 jedi==0.18.2
     # via ipython


### PR DESCRIPTION
I guess this should eventually be done with #26, but I don't know anything about `pip-compile`, so I'm updating it manually for now.

The syntax highlighting in IPython 8.7.0 is broken, see https://github.com/spatialaudio/nbsphinx/issues/687.